### PR TITLE
Add :@headers argument for WebSocket client

### DIFF
--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -61,9 +61,10 @@ class Cro::WebSocket::Client {
             my $magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
             my $answer = encode-base64(sha1($key ~ $magic), :str);
 
-            @!headers.push: Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key);
+            my @headers = @!headers;
+            @headers.push: Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key);
 
-            my %options = headers => @!headers.item;
+            my %options = headers => @headers.item;
             %options<body-byte-stream> = $out.Supply;
             my $resp = await Cro::HTTP::Client.get($parsed-url, %options, :%ca);
             if $resp.status == 101 {

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -62,7 +62,7 @@ class Cro::WebSocket::Client {
             my $answer = encode-base64(sha1($key ~ $magic), :str);
 
             my @headers = do if self {
-                @!headers.clone.push: Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key)
+                flat @!headers, Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key)
             } else {
                 (Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
                  Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -61,8 +61,15 @@ class Cro::WebSocket::Client {
             my $magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
             my $answer = encode-base64(sha1($key ~ $magic), :str);
 
-            my @headers = @!headers;
-            @headers.push: Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key);
+            my @headers = do if self {
+                @!headers.clone.push: Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key)
+            } else {
+                (Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
+                 Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),
+                 Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13'),
+                 Cro::HTTP::Header.new(name => 'Sec-WebSocket-Key', value => $key),
+                 Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol'))
+            }
 
             my %options = headers => @headers.item;
             %options<body-byte-stream> = $out.Supply;

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -38,7 +38,7 @@ class Cro::WebSocket::Client {
                     Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),
                     Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13'),
                     Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol');
-        @!headers.push($_) for @headers;
+        @!headers.append(@headers);
     }
 
     method connect($uri = '', :%ca? --> Promise) {

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -71,7 +71,7 @@ class Cro::WebSocket::Client {
                  Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol'))
             }
 
-            my %options = headers => @headers.item;
+            my %options = headers => @headers;
             %options<body-byte-stream> = $out.Supply;
             my $resp = await Cro::HTTP::Client.get($parsed-url, %options, :%ca);
             if $resp.status == 101 {

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -34,10 +34,10 @@ class Cro::WebSocket::Client {
             $!body-serializers = $body-serializers;
         }
 
-        @!headers = [Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
-                     Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),
-                     Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13'),
-                     Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol')];
+        @!headers = Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
+                    Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),
+                    Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13'),
+                    Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol');
         @!headers.push($_) for @headers;
     }
 

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -34,10 +34,10 @@ class Cro::WebSocket::Client {
             $!body-serializers = $body-serializers;
         }
 
-        @!headers = (Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
+        @!headers = [Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
                      Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),
                      Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13'),
-                     Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol'));
+                     Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol')];
         @!headers.push($_) for @headers;
     }
 


### PR DESCRIPTION
Hi,

I add `:@headers` argument to set optional headers.

The reasons to add this feature:

1) Some of the other implementations (e.g., https://github.com/websockets/ws) have the optional headers argument.
2) Some of the servers require additional header parameter for authentication (e.g., https://docs.openstack.org/zaqar/latest/configuration/configuring.html).