### PR TITLE
Make "Upgrade" matching case-insensitive

### DIFF
--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -65,7 +65,7 @@ class Cro::WebSocket::Client {
             if $resp.status == 101 {
                 # Headers check;
                 die unless $resp.header('upgrade') eq 'websocket';
-                die unless $resp.header('connection') eq 'Upgrade';
+                die unless $resp.header('connection') ~~ m:i/Upgrade/;
                 die unless $resp.header('Sec-WebSocket-Accept').trim eq $answer;
                 # No extensions for now
                 # die unless $resp.header('Sec-WebSocket-Extensions') eq Nil;

--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -65,7 +65,7 @@ class Cro::WebSocket::Client {
             if $resp.status == 101 {
                 # Headers check;
                 die unless $resp.header('upgrade') eq 'websocket';
-                die unless $resp.header('connection') ~~ m:i/Upgrade/;
+                die unless $resp.header('connection') ~~ m:i/^Upgrade$/;
                 die unless $resp.header('Sec-WebSocket-Accept').trim eq $answer;
                 # No extensions for now
                 # die unless $resp.header('Sec-WebSocket-Extensions') eq Nil;


### PR DESCRIPTION
RFC6455 (c.f., https://tools.ietf.org/html/rfc6455#section-4.1) says:
```
If the response lacks a |Connection| header field or the
|Connection| header field doesn't contain a token that is an
ASCII case-insensitive match for the value "Upgrade", the client
MUST _Fail the WebSocket Connection_.
```