### PR TITLE
Fix mishandling of 2-byte extended payload length

### DIFF
--- a/lib/Cro/WebSocket/FrameParser.pm6
+++ b/lib/Cro/WebSocket/FrameParser.pm6
@@ -65,7 +65,6 @@ class Cro::WebSocket::FrameParser does Cro::Transform {
                         if $data.elems < 2 {
                             $buffer.append: $data; last;
                         } else {
-                            die 'Length cannot be negative' if self!check-first-bit($data[0]);
                             $length = ($data[0] +< 8) +| $data[1];
                             $data .= subbuf(2);
                             $expecting = MaskKey; next;

--- a/t/websocket-frame-parser.t
+++ b/t/websocket-frame-parser.t
@@ -104,6 +104,22 @@ test-example $message,
              *.payload == @random-data,
              split => True;
 
+@random-data = 255.rand.Int xx 32768;
+$message = Buf.new([0x82, 0x7E, 0x80, 0x00, |@random-data]);
+
+test-example $message,
+             False, '32 KiB binary message in a single unmasked frame',
+             *.fin == True,
+             *.opcode == Cro::WebSocket::Frame::Binary,
+             *.payload == @random-data;
+
+test-example $message,
+             False, '32 KiB binary message in a single unmasked frame',
+             *.fin == True,
+             *.opcode == Cro::WebSocket::Frame::Binary,
+             *.payload == @random-data,
+             split => True;
+
 @random-data = 255.rand.Int xx 65536;
 $message = Buf.new([0x82, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, |@random-data]);
 

--- a/t/websocket-frame-serializer.t
+++ b/t/websocket-frame-serializer.t
@@ -69,6 +69,13 @@ test-example Cro::WebSocket::Frame.new(fin => True,
                                        payload => Blob.new(@random-data)),
              False, '256 bytes binary message in a single unmasked frame';
 
+@random-data = 255.rand.Int xx 32768;
+
+test-example Cro::WebSocket::Frame.new(fin => True,
+                                       opcode => Cro::WebSocket::Frame::Binary,
+                                       payload => Blob.new(@random-data)),
+             False, '32 KiB binary message in a single unmasked frame';
+
 @random-data = 255.rand.Int xx 65536;
 
 test-example Cro::WebSocket::Frame.new(fin => True,


### PR DESCRIPTION
This fixes https://github.com/croservices/cro-websocket/issues/23 in which
Cro::WebSocket::FrameParser incorrectly bans 2-byte extended payload lengths
with the high bit set (lengths are unsigned according to RFC 6455, and the
high bit check only applies to 8-byte lengths).

Also add tests to check that payloads of length 2¹⁵ are correctly handled.