### PR TITLE
Allow Sec-WebSocket-Version overridding

### DIFF
--- a/lib/Cro/WebSocket/Client.pm6
+++ b/lib/Cro/WebSocket/Client.pm6
@@ -44,8 +44,10 @@ class Cro::WebSocket::Client {
 
         @!headers = Cro::HTTP::Header.new(name => 'Upgrade', value => 'websocket'),
                     Cro::HTTP::Header.new(name => 'Connection', value => 'Upgrade'),
-                    Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13'),
-                    Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol');
+                    Cro::HTTP::Header.new(name => 'Sec-WebSocket-Version', value => '13');
+        without @headers.first(*.name.lc eq 'sec-websocket-protocol') {
+            @!headers.append(Cro::HTTP::Header.new(name => 'Sec-WebSocket-Protocol', value => 'echo-protocol'));
+        }
         @!headers.append(@headers);
     }
 


### PR DESCRIPTION
A "simple" solution for https://github.com/croservices/cro-websocket/issues/13
However, as we don't care about subprotocols in our server, there is no easy way to really check that.
Maybe we should add some subprotocol negotiation on the server end as well? In the meanwhile, it allows to override the header causing troubles for users.