### PR TITLE
Make web-socket() routine a multi

### DIFF
--- a/lib/Cro/HTTP/Router/WebSocket.pm6
+++ b/lib/Cro/HTTP/Router/WebSocket.pm6
@@ -9,7 +9,7 @@ use Cro::WebSocket::Internal;
 use Cro::WebSocket::MessageParser;
 use Cro::WebSocket::MessageSerializer;
 
-sub web-socket(&handler, :$json, :$body-parsers is copy,  :$body-serializers is copy) is export {
+multi web-socket(&handler, :$json, :$body-parsers is copy,  :$body-serializers is copy) is export {
     my constant $magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
     my $request = request;


### PR DESCRIPTION
Like it says on the tin: I want to defer to this `web-socket()` from a multi I'm adding in my module for CBOR support.